### PR TITLE
Swap JSON.pm -> JSON::XS.pm so WWW::Testafy.pm works.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,6 @@
 WWW::Testafy has 3 dependencies that should be installed separately (for the time being). They are:
     Moose
-    JSON
+    JSON::XS
     LWP::UserAgent
 
 All three are on CPAN.

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ perl
 Testafy's perl API wrapper
 Dependencies:
     Moose
-    JSON
+    JSON::XS
     LWP::UserAgent

--- a/WWW/Testafy.pm
+++ b/WWW/Testafy.pm
@@ -26,7 +26,7 @@ package WWW::Testafy;
 =cut
 
 use Moose;
-use JSON;
+use JSON::XS ();
 use LWP::UserAgent;
 
 =head1 ATTRIBUTES
@@ -119,7 +119,7 @@ sub make_api_request {
 
     $request_vars->{login_name} = $self->testafy_username;
     my $r = {
-        json => to_json($request_vars)
+        json => JSON::XS::encode_json($request_vars)
     };
 
     $self->ua->credentials(
@@ -131,7 +131,7 @@ sub make_api_request {
     
     $self->response($self->ua->post($uri, $r));
     if (my $content = $self->response->content) {
-        eval { $self->response_vars(from_json($content)); };
+        eval { $self->response_vars(JSON::XS::decode_json($content)); };
         $self->response_vars({error => [ $content]}) if $@;
     }
 


### PR DESCRIPTION
WWW::Testafy with JSON.pm does not work with all versions of JSON.pm.
Switching to JSON::XS instead makes WWW::Testafy work as advertised.
